### PR TITLE
remove needless module

### DIFF
--- a/t/02-responses.t
+++ b/t/02-responses.t
@@ -5,7 +5,6 @@ use strict;
 use Test::More;
 use Test::Fatal;
 use Test::Deep;
-use IO::String;
 use Redis::Fast;
 use IO::Socket::INET;
 use Test::TCP;


### PR DESCRIPTION
This test is failed on some platform where is not installed `IO::String`.
But `IO::String` is not used in this test.
