### PR TITLE
Use gmake for building library on BSD platform except KFreeBSD

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,6 +2,7 @@ requires 'perl', '5.008001';
 
 on 'configure' => sub{
     requires 'Module::Build::XSUtil' => '>=0.02';
+    requires 'File::Which';
 };
 
 on 'test' => sub {


### PR DESCRIPTION
Because deps/hiredis/Makefile is GNU Makefile.
On BSD platform, 'make' stands for BSDMake except KFreeBSD.

Please see this patch.
