### PR TITLE
Missing test case for https://github.com/shogo82148/Redis-Fast/issues/9

### DIFF
--- a/t/53-blpop_and_timeout.t
+++ b/t/53-blpop_and_timeout.t
@@ -1,0 +1,23 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Fatal;
+use Redis::Fast;
+use lib 't/tlib';
+use Test::SpawnRedisServer;
+
+my ($c, $srv) = redis();
+END { $c->() if $c }
+
+unless (fork()) {
+    my $redis = Redis::Fast->new(server => $srv, name => 'my_name_is_glorious', reconnect=>1, read_timeout  => 0.3);
+    eval { $redis->blpop("notakey", 1); };
+    exit 0;
+}
+
+wait;
+
+is $?, 0, "does not crash when read_timeout is smaller than BLPOP timeout";
+
+
+done_testing;


### PR DESCRIPTION
fork another process, try reproduce issue. Check that child process didn't crash,
i.e. exit code is zero

named it `53*` - I assume those are tests unique for `Redis::Fast`, other copied from `Redis`.
