### PR TITLE
Support topic "0" in psubscribe

### DIFF
--- a/lib/Redis/Fast.pm
+++ b/lib/Redis/Fast.pm
@@ -387,7 +387,7 @@ sub __process_pubsub_msg {
   my $sub   = $m->[1];
   my $cbid  = "$m->[0]:$sub";
   my $data  = pop @$m;
-  my $topic = $m->[2] || $sub;
+  my $topic = defined $m->[2] ? $m->[2] : $sub;
 
   if (!exists $subs->{$cbid}) {
     warn "Message for topic '$topic' ($cbid) without expected callback, ";

--- a/t/03-pubsub.t
+++ b/t/03-pubsub.t
@@ -131,8 +131,8 @@ subtest 'basics' => sub {
 
 subtest 'zero_topic' => sub {
   my %got;
-  my $pub = Redis->new(server => $srv);
-  my $sub = Redis->new(server => $srv);
+  my $pub = Redis::Fast->new(server => $srv);
+  my $sub = Redis::Fast->new(server => $srv);
 
   my $db_size = -1;
   $sub->dbsize(sub { $db_size = $_[0] });


### PR DESCRIPTION
porting of https://github.com/PerlRedis/perl-redis/pull/106

> There was no way of getting the original topic name in pubsub messages received via PSUBSCRIBE if the name of the topic was "falsy" in Perl sense.
> 
> A test and a basic '||' vs. 'defined' fix.