### PR TITLE
disable wide char check, let user decide (like Redis module)

### DIFF
--- a/src/Redis__Fast.xs
+++ b/src/Redis__Fast.xs
@@ -1068,9 +1068,11 @@ CODE:
     Newx(argvlen, sizeof(size_t) * argc, size_t);
 
     for (i = 0; i < argc; i++) {
+/*
         if(!sv_utf8_downgrade(ST(i + 1), 1)) {
             croak("command sent is not an octet sequence in the native encoding (Latin-1). Consider using debug mode to see the command itself.");
         }
+*/
         argv[i] = SvPV(ST(i + 1), len);
         argvlen[i] = len;
     }

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -46,10 +46,12 @@ cmp_ok($o->get('foo'), 'eq', 'baz', 'get foo = baz');
 
 my $euro = "\x{20ac}";
 ok ord($euro) > 255, "assume \$eur is wide character";
-ok ! eval { $o->set(utf8 => $euro); 1 }, "accepts only binary data, thus crashes on strings with characters > 255";
-like "$@", qr/command sent is not an octet sequence in the native encoding/i, ".. and crashes on syswrite call";
+ok $o->set(utf8 => $euro), "we don't care about the content";
 
-ok ! defined $o->get('utf8'), ".. and does not write actual data";
+my $check_euro = $o->get('utf8');
+utf8::decode($check_euro);
+ok ord($check_euro) > 255, "assume \$check_eur is wide character";
+is $check_euro,$euro, ".. and the data is here";
 
 ok($o->set('test-undef' => 42), 'set test-undef');
 ok($o->exists('test-undef'), 'exists undef');


### PR DESCRIPTION
In Redis module, we don't care about what we send in Redis. So the utf8 check is useless. Let the user decide what he send.