### PR TITLE
Allow Redis::Fast to be installed with cpanminus from github.

### DIFF
--- a/builder/MyBuilder.pm
+++ b/builder/MyBuilder.pm
@@ -30,9 +30,9 @@ sub new {
     }
     if (-e '.git') {
         unless (-e 'deps/hiredis/Makefile') {
-            die 'This repository has submodules and needs "git submodule update --init" to be built'
+            $self->do_system('git','submodule','update','--init');
         }
-    }       
+    }   
     $self->do_system($make, '-C', 'deps/hiredis', 'static');
     return $self;
 }

--- a/xt/release/kwalitee.t
+++ b/xt/release/kwalitee.t
@@ -1,2 +1,10 @@
+BEGIN {
+    if (-e '.git') {       
+        require Test::More;
+	Test::More::plan(skip_all=>'Installing from a git repository omiting Kwalitee tests.');
+    }
+}
+
 use Test::More;
+
 use Test::Kwalitee::Extra qw(:retry 1 :experimental);


### PR DESCRIPTION
The two commits of this paht allow us to install the distribution directlly from the github URL with by updating the submodules and skiping kwalitee tests when building the modlules from the git repository.

When building the distribution or releasing it with Minilla the test run as intended