### PR TITLE
Disconnect inside transaction

### DIFF
--- a/src/Redis__Fast.xs
+++ b/src/Redis__Fast.xs
@@ -668,9 +668,7 @@ static redis_fast_reply_t  Redis__Fast_run_cmd(Redis__Fast self, int collect_err
         if(res == WAIT_FOR_EVENT_READ_TIMEOUT || res == WAIT_FOR_EVENT_WRITE_TIMEOUT) {
             if(self->flags & (FLAG_INSIDE_TRANSACTION | FLAG_INSIDE_WATCH)) {
                 self->is_connected = 0;
-                self->ac->replies.head = NULL;
-                self->ac->replies.tail = NULL;
-                redisAsyncDisconnect(self->ac);
+                redisAsyncFree(self->ac);
             }
             snprintf(self->error, MAX_ERROR_SIZE, "Error while reading from Redis server: %s", strerror(EAGAIN));
             croak("%s", self->error);

--- a/src/Redis__Fast.xs
+++ b/src/Redis__Fast.xs
@@ -666,6 +666,12 @@ static redis_fast_reply_t  Redis__Fast_run_cmd(Redis__Fast self, int collect_err
         // else destructor will release cbt
 
         if(res == WAIT_FOR_EVENT_READ_TIMEOUT || res == WAIT_FOR_EVENT_WRITE_TIMEOUT) {
+            if(self->flags & (FLAG_INSIDE_TRANSACTION | FLAG_INSIDE_WATCH)) {
+                self->is_connected = 0;
+                self->ac->replies.head = NULL;
+                self->ac->replies.tail = NULL;
+                redisAsyncDisconnect(self->ac);
+            }
             snprintf(self->error, MAX_ERROR_SIZE, "Error while reading from Redis server: %s", strerror(EAGAIN));
             croak("%s", self->error);
         }


### PR DESCRIPTION
- call `redisAsyncDisconnect` inside transaction or watch
- add disconnect test
