### PR TITLE
use unix domain socket

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -12,6 +12,8 @@ on 'test' => sub {
     requires 'File::Temp';
     requires 'Test::Deep';
     requires 'Test::TCP';
+    requires 'Test::UNIXSock';
+    requires 'Parallel::ForkManager';
     requires 'Test::Fatal';
     requires 'Test::SharedFork';
     requires 'Test::LeakTrace';

--- a/t/02-responses.t
+++ b/t/02-responses.t
@@ -32,7 +32,6 @@ sub r {
         },
         client => sub {
             my $path = shift;
-            warn 'connect';
             ok(my $r = Redis::Fast->new(sock => $path), 'connected to our test redis-server');
             $test->($r);
         },

--- a/t/02-responses.t
+++ b/t/02-responses.t
@@ -6,31 +6,34 @@ use Test::More;
 use Test::Fatal;
 use Test::Deep;
 use Redis::Fast;
-use IO::Socket::INET;
-use Test::TCP;
-
+use IO::Socket::UNIX;
+use Test::UNIXSock;
+use Parallel::ForkManager;
 
 sub r {
     my ($response, $test) = @_;
-    test_tcp(
+    test_unix_sock(
         server => sub {
-            my $port = shift;
-            my $sock = IO::Socket::INET->new(
-                LocalPort => $port,
-                LocalAddr => '127.0.0.1',
-                Proto     => 'tcp',
-                Listen    => 5,
+            my $path = shift;
+            my $sock = IO::Socket::UNIX->new(
+                Local     => $path,
+                Listen    => 1,
                 Type      => SOCK_STREAM,
             ) or die "Cannot open server socket: $!";
 
             my $res = join '', map "$_\r\n", @$response;
+            my $pm = Parallel::ForkManager->new(10);
             while(my $remote = $sock->accept) {
+                my $pid = $pm->start and next;
+                <$remote>; # ignore commands from client
                 print {$remote} $res;
+                $pm->finish;
             }
         },
         client => sub {
-            my $port = shift;
-            ok(my $r = Redis::Fast->new(server => "127.0.0.1:$port"), 'connected to our test redis-server');
+            my $path = shift;
+            warn 'connect';
+            ok(my $r = Redis::Fast->new(sock => $path), 'connected to our test redis-server');
             $test->($r);
         },
     );


### PR DESCRIPTION
 because Test::TCP sometimes dies with "Address already use"