### PR TITLE
Fixed: pass tests for MacOSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
   - REDIS_VERSION=2.8.23 TEST_LANG=ja_JP.UTF-8
 before_install:
   - if which apt-get >/dev/null; then sudo apt-get update && sudo apt-get --reinstall install -qq language-pack-en language-pack-ja; fi
+  # Root owner of $HOME/perl5 causes a perlbrew installation error.
+  - if [[ $TRAVIS_OS_NAME = osx ]] && [ -e "$HOME/perl5" ] ; then sudo chown -R $(whoami):staff $HOME/perl5; fi
   - curl -L http://install.perlbrew.pl | bash
   - source ~/perl5/perlbrew/etc/bashrc
   - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ before_install:
   - curl -L http://install.perlbrew.pl | bash
   - source ~/perl5/perlbrew/etc/bashrc
   - git clone git://github.com/travis-perl/helpers ~/travis-perl-helpers
+  # Existence of prebuilt perl causes a build-perl error.
+  - if [[ $TRAVIS_OS_NAME = osx ]]; then perlbrew list | xargs perlbrew uninstall; fi
   - source ~/travis-perl-helpers/init
   - if [[ $TRAVIS_OS_NAME = osx ]]; then export REBUILD_PERL=1; fi
   - build-perl


### PR DESCRIPTION
I could not understand why the previously passed tests made failures, so that I fixed only each direct causes.
- Changed the owner from root to travis to avoid a permission error 8949eeb
  - See https://travis-ci.org/yoheimuta/Redis-Fast/jobs/151999933#L306-L319
  - Excerpt from the link is below.

```
$ curl -L http://install.perlbrew.pl | bash
...
## Installing perlbrew
perlbrew is installed: ~/perl5/perlbrew/bin/perlbrew
mkdir /Users/travis/perl5/perlbrew/dists: Permission denied at perlbrew.v98ZuU line 121.
```
- Uninstalled a prebuilt perl installation of perlbrew 5396a5b
  - See https://travis-ci.org/yoheimuta/Redis-Fast/jobs/154030504#L626-L627 and https://travis-ci.org/yoheimuta/Redis-Fast/jobs/154030504#L102-L103.
  - The prebuilt perl is not available because this is broken ( https://travis-ci.org/yoheimuta/Redis-Fast/jobs/154030504#L297 ).
  - Excerpt from the link is below.

```
+echo 'Perl 5.14 already installed.'
Perl 5.14 already installed.
```
