### PR TITLE
Support reconnecting on the specified error

### DIFF
--- a/META.json
+++ b/META.json
@@ -119,7 +119,8 @@
       "nise_nabe <nise.nabe@gmail.com>",
       "Vincent <vincent@weborama.com>",
       "Jose Luis Perez Diez <jluis@escomposlinux.org>",
-      "Syohei YOSHIDA <syohex@gmail.com>"
+      "Syohei YOSHIDA <syohex@gmail.com>",
+      "yoheimuta <yoheimuta@gmail.com>"
    ],
    "x_serialization_backend" : "JSON::PP version 2.27202"
 }

--- a/scripts/reconnect_on_error.pl
+++ b/scripts/reconnect_on_error.pl
@@ -1,0 +1,82 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+use 5.010;
+use lib 'lib';
+use Test::More;
+use Redis::Fast;
+
+my $test_mode_sync=0;
+
+my $r = Redis::Fast->new(
+    reconnect          => 1,
+    server             => 'localhost:6380',
+    reconnect_on_error => sub {
+        my ($error, $ret, $command) = @_;
+        $ret ||= "";
+
+        my $next_reconnect = -1;
+        if ($error =~ /READONLY You can't write against a read only slave/) {
+            $next_reconnect = 2;
+        }
+
+        diag "cb: error=$error, ret=$ret, command=$command, next=$next_reconnect";
+        return $next_reconnect;
+    },
+);
+
+my $key = 'hoge';
+my $ret = $r->get($key);
+ok !$ret, "no data" or diag $ret;
+
+sleep 30;
+
+my $value = 'fuga';
+for my $i (1..30) {
+    if ($test_mode_sync) {
+        eval { $r->setex($key, 1, $value) };
+        if ($@) {
+            diag "Sleep and next: tried $i time(s), ignore error=$@";
+            sleep 1;
+            next;
+        }
+        $ret = $r->get($key);
+        is $ret, $value, 'did reconnect with master'
+            or die '[BUG] test code is broken';
+        done_testing();
+        exit 0;
+    } else {
+        my $error;
+        $r->setex($key, 1, $value, sub {
+            my ($ret, $_error) = @_;
+            unless ($_error) {
+                $ret = $r->get($key);
+                is $ret, $value, 'did reconnect with master'
+                    or die '[BUG] test code is broken';
+                done_testing();
+                exit 0;
+            }
+            $error = $_error;
+        });
+        $r->wait_all_responses;
+        diag "Sleep and next: tried $i time(s), ignore error=$error";
+        sleep 1;
+    }
+}
+
+ok 0, 'did not reconnect with master';
+
+done_testing();
+
+__END__
+# Manual for an operation test
+## NOTE: Turn off `close-on-slave-write` parameter for the ElastiCache Redis.
+## 1. Set a redis cluster endpoint url to a server parameter.
+## 2. Manual failover to hoge-redis2
+aws elasticache modify-replication-group \
+--replication-group-id hoge-redis-cluster \
+--primary-cluster-id hoge-redis2 \
+--apply-immediately
+## 3. READONLY errors happen until reconnecting with a new master endpoint.
+## 4. This tests are ok after a reconnection.

--- a/src/Redis__Fast.xs
+++ b/src/Redis__Fast.xs
@@ -613,6 +613,11 @@ static void Redis__Fast_quit(Redis__Fast self) {
     cbt->ret.result = NULL;
     cbt->ret.error = NULL;
     cbt->custom_decode = NULL;
+
+    // initialize, or self->flags will be corrupted.
+    cbt->on_flags = 0;
+    cbt->off_flags = 0;
+
     redisAsyncCommand(
         self->ac, Redis__Fast_sync_reply_cb, cbt, "QUIT"
         );

--- a/src/Redis__Fast.xs
+++ b/src/Redis__Fast.xs
@@ -501,7 +501,7 @@ static int Redis__Fast_call_reconnect_on_error(Redis__Fast self, redis_fast_repl
 
         sv_ret = ret.result ? ret.result : sv_2mortal(newSV(0));
         sv_err = ret.error;
-        sv_cmd = sv_2mortal(newSVpvn(command_name, command_length));
+        sv_cmd = sv_2mortal(newSVpvn((const char*)command_name, command_length));
 
         PUSHMARK(SP);
         XPUSHs(sv_err);

--- a/t/07-reconnect-on-error.t
+++ b/t/07-reconnect-on-error.t
@@ -1,0 +1,228 @@
+#!perl
+
+use warnings;
+use strict;
+use Test::More;
+use Test::Fatal;
+use Redis::Fast;
+use lib 't/tlib';
+use Test::SpawnRedisServer;
+
+my ($c, $srv) = redis(timeout => 1);
+END { $c->() if $c }
+
+# Reconnect once
+# when
+## 1. reconnect is greater than 0
+## 2. and reconnect_on_error returns a value greater than and equal to 0
+## 3. and a specified time seconds elapsed
+
+sub new_redis_fast {
+    my ($reconnect, $reconnect_on_error) = @_;
+    return Redis::Fast->new(
+        reconnect          => $reconnect,
+        server             => $srv,
+        reconnect_on_error => $reconnect_on_error,
+    );
+}
+my $cb_call_count = 0;
+my $sync_call_hset = sub {
+    my ($client, $hint)  = @_;
+    like (exception { $client->hset(1,1) },
+        qr{ERR wrong number of arguments for 'hset' command},
+        'syntax error')
+        or diag "hint=$hint";
+    return 'sync';
+};
+my $async_call_hset = sub {
+    my ($client, $hint)  = @_;
+    my $_cb_call_count = 0;
+    my $_cb = sub {
+        my ($ret, $error) = @_;
+        is $error, "ERR wrong number of arguments for 'hset' command"
+            or diag "_cb_call_count=$_cb_call_count, hint=$hint";
+        ok !$ret
+            or diag "_cb_call_count=$_cb_call_count, hint=$hint";
+        $_cb_call_count++;
+    };
+    $client->hset(1,1,$_cb);
+    $client->hset(2,2,$_cb);
+    $client->wait_all_responses;
+    is $_cb_call_count, 2;
+    return 'async';
+};
+
+# Check a condition 1.
+{
+    my $cb = sub {
+        my ($error, $ret, $cmd) = @_;
+
+        # increment a counter to test it later.
+        $cb_call_count++;
+
+        # tests each argument.
+        is $error, "ERR wrong number of arguments for 'hset' command";
+        ok !$ret;
+        is $cmd, 'HSET';
+        return 0;
+    };
+
+    for my $reconnect (0, 1) {
+        for my $call_hset ($sync_call_hset, $async_call_hset) {
+            my $r = new_redis_fast($reconnect, $cb);
+            my $hint = $call_hset->($r, $reconnect);
+
+            if ($reconnect == 0) {
+                is $cb_call_count, 0, 'do not call reconnect_on_error'
+                    or diag "call=$hint";
+            } else {
+                is $cb_call_count, 1, 'call reconnect_on_error once'
+                    or diag "call=$hint";
+            }
+
+            # reset a counter
+            $cb_call_count = 0;
+        }
+    }
+}
+
+# Check a condition 2.
+{
+    my $get_client_list = sub {
+        my $r_get_conn = new_redis_fast();
+        my $list = $r_get_conn->client_list;
+        my @list = split "\n", $list;
+        return @list;
+    };
+    my $kill_all_client = sub {
+        my $r_kill_conn = new_redis_fast();
+        my $ret = $r_kill_conn->client_kill('TYPE', 'normal');
+        undef $r_kill_conn;
+
+        my @list = $get_client_list->();
+        unless (scalar @list == 1) {
+            die "[BUG] client should be only r_get_con itself: list=" . (join "\n", @list);
+        }
+    };
+
+    my $cb = sub {
+        my $cb_return_value = shift;
+
+        return sub {
+            my ($error, $ret, $cmd) = @_;
+
+            # increment a counter to test it later.
+            $cb_call_count++;
+
+            # quit to test whether reconnect or not.
+            $kill_all_client->();
+
+            return $cb_return_value;
+        }
+    };
+
+    for my $cb_return_value (-1, 0) {
+        for my $call_hset ($sync_call_hset, $async_call_hset) {
+            my $reconnect = 1;
+
+            my $r = new_redis_fast($reconnect, $cb->($cb_return_value));
+            my $hint = $call_hset->($r, $cb_return_value);
+
+            if ($cb_return_value == -1 && $hint eq 'async') {
+                # If $cb_return_value is 0 and then $self->need_recoonect is set,
+                # calling the reconnect_on_error cb again is useless cost.
+                is $cb_call_count, 2, 'call reconnect_on_error each async call for hset'
+                    or diag "cb_return_value=$cb_return_value, hint=$hint";
+            } else {
+                is $cb_call_count, 1, 'call reconnect_on_error once'
+                    or diag "cb_return_value=$cb_return_value, hint=$hint";
+            }
+
+            my @client_list = $get_client_list->();
+            if ($cb_return_value == -1) {
+                is scalar @client_list, 1, 'do not reconnect after a contrived quit'
+                    or diag explain \@client_list . ", hint=$hint";
+            } else {
+                is scalar @client_list, 2, 'reconnect after a contrived quit'
+                    or diag explain \@client_list . ", hint=$hint";
+            }
+            # reset a counter
+            $cb_call_count = 0;
+        }
+    }
+}
+
+# Check a condition 3.
+{
+    my $cb_return_value = 0;
+    my $cb = sub {
+        my ($error, $ret, $cmd) = @_;
+
+        # increment a counter to test it later.
+        $cb_call_count++;
+
+        return $cb_return_value;
+    };
+
+    my $reconnect = 1;
+
+    # Do not call a reconnect_on_error before a second elapse.
+    {
+        for my $call_hset ($sync_call_hset, $async_call_hset) {
+            my $r = new_redis_fast($reconnect, $cb);
+
+            for my $_cb_return_value (0, 1, 2) {
+                $cb_return_value = $_cb_return_value;
+                my $hint = $call_hset->($r, $_cb_return_value);
+
+                if ($_cb_return_value == 0) {
+                    # once: call a cb and return 0.
+                    is $cb_call_count, 1, 'call reconnect_on_error once'
+                        or diag "cb_return_value=$_cb_return_value, call=$hint";
+                } else {
+                    # twice: do not wait, so call a cb and return 1.
+                    is $cb_call_count, 2, 'call reconnect_on_error twice, not 3 or 4 times'
+                        or diag "cb_return_value=$_cb_return_value, call=$hint";
+                }
+                # do not sleep a second
+                # do not reset a counter
+            }
+            # reset a counter
+            $cb_call_count = 0;
+        }
+    }
+
+    # Call a reconnect_on_error after a second elapse.
+    {
+        for my $call_hset ($sync_call_hset, $async_call_hset) {
+            my $r = new_redis_fast($reconnect, $cb);
+            for my $_cb_return_value (0, 1, 2) {
+                $cb_return_value = $_cb_return_value;
+                my $hint = $call_hset->($r, $_cb_return_value);
+
+                if ($_cb_return_value == 0) {
+                    # once: call a cb and return 0.
+                    is $cb_call_count, 1, 'call reconnect_on_error once'
+                        or diag "cb_return_value=$_cb_return_value, call=$hint";
+                } elsif ($_cb_return_value == 1) {
+                    # twice: do not wait, so call a cb and return 1.
+                    is $cb_call_count, 2, 'call reconnect_on_error twice'
+                        or diag "cb_return_value=$_cb_return_value, call=$hint";
+                } else {
+                    # 3 times: wait for a second, so call a cb and return 2.
+                    is $cb_call_count, 3, 'call reconnect_on_error 3 times, not 4 times'
+                        or diag "cb_return_value=$_cb_return_value, call=$hint";
+                }
+
+                # A second elapsed
+                sleep 1;
+
+                # do not reset a counter
+            }
+            # reset a counter
+            $cb_call_count = 0;
+        }
+    }
+}
+
+done_testing();

--- a/t/51-leak.t
+++ b/t/51-leak.t
@@ -58,4 +58,31 @@ no_leaks_ok {
     $r->unsubscribe('hogehoge', $cb);
 } 'unsubscribe';
 
+no_leaks_ok {
+    my $r = Redis::Fast->new(
+        server => $srv,
+        reconnect => 1,
+        reconnect_on_error => sub {
+            my $force_reconnect = 1;
+            return $force_reconnect;
+        },
+    );
+    eval { $r->hset(1,1) };
+} 'sync reconnect_on_error';
+
+no_leaks_ok {
+    my $r = Redis::Fast->new(
+        server => $srv,
+        reconnect => 1,
+        reconnect_on_error => sub {
+            my $force_reconnect = 1;
+            return $force_reconnect;
+        },
+    );
+    my $cb = sub {};
+    $r->hset(1,1,$cb);
+    $r->hset(2,2,$cb);
+    eval { $r->wait_all_responses };
+} 'async reconnect_on_error';
+
 done_testing;


### PR DESCRIPTION
Adds a support for a known issue in ElastiCache failover. We must wrap all sync write calls and async wait calls without the library support. It costs a speed penalty by boilerplates and missings by mistakes.

I'm posting this to get more feedbacks on the output because this is large and the detail is not issued yet.

See
- Issues in ElastiCache Redis
  - http://qiita.com/dany1468/items/8946cd5e4c853b48bffd -- in japanese
  - https://github.com/luin/ioredis/issues/144
- An interface design example
  - https://github.com/luin/ioredis#reconnect-on-error

I expect that this pr tests are passed after #56 is merged.
