### PR TITLE
fix missing prerequisite: Tie::StdHash

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 requires 'perl', '5.008001';
 requires 'Try::Tiny';
 requires 'Time::HiRes';
+requires 'Tie::StdHash';
 
 on 'configure' => sub{
     requires 'Module::Build::XSUtil' => '>=0.02';


### PR DESCRIPTION
```
#   Failed test 'prereq_matches_use by Test::Kwalitee::Extra'
#   at xt/release/kwalitee.t line 10.
#   Detail: This distribution uses a module or a dist that's not listed as a prerequisite.
#   Detail: Missing: Tie::StdHash in perl
#   Remedy: List all used modules in META.yml requires
```