### PR TITLE
Fix inheriting from Tie::StdHash

### DIFF
--- a/lib/Redis/Fast/Hash.pm
+++ b/lib/Redis/Fast/Hash.pm
@@ -6,8 +6,9 @@ package Redis::Fast::Hash;
 
 use strict;
 use warnings;
-use Tie::Hash;
-use base qw/Redis::Fast Tie::StdHash/;
+require Tie::Hash;
+require Redis::Fast;
+our @ISA = qw(Redis::Fast Tie::StdHash);
 
 
 sub TIEHASH {


### PR DESCRIPTION
According to the [document of Tie::Hash](https://metacpan.org/pod/distribution/perl/lib/Tie/Hash.pm), the following code is correct

``` perl
package NewStdHash;
require Tie::Hash;
 
@ISA = qw(Tie::StdHash);
```