### PR TITLE
Fix info command error message

### DIFF
--- a/lib/Redis/Fast.pm
+++ b/lib/Redis/Fast.pm
@@ -309,7 +309,7 @@ sub info {
     my $self = shift;
     $self->__is_valid_command('info');
     my ($ret, $error) = $self->__info(@_);
-    confess "[keys] $error, " if defined $error;
+    confess "[info] $error, " if defined $error;
     return $ret unless ref $ret eq 'ARRAY';
     return @$ret;
 }


### PR DESCRIPTION
`[keys]` is felt strange. 
`[info] ~` is maybe correct message.

Please check it.