### PR TITLE
drop support of Perl 5.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: perl
-dist: bionic
+dist: xenial
 perl:
   - "5.30"
   - "5.28"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,6 @@ perl:
   - "5.26"
   - "5.24"
   - "5.22"
-  - "5.20"
-  - "5.18"
-  - "5.16"
-  - "5.14"
-  - "5.12"
-  - "5.10"
 os:
   - linux
 # Unfortunately, perl in osx is currently broken.

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
   - REDIS_VERSION=3.2.13 TEST_LANG=en_US.UTF-8
   - REDIS_VERSION=2.8.24 TEST_LANG=en_US.UTF-8
   - REDIS_VERSION=4.0.14 TEST_LANG=ja_JP.UTF-8
-sudo: false
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: perl
+dist: bionic
 perl:
   - "5.30"
   - "5.28"

--- a/Build.PL
+++ b/Build.PL
@@ -25,7 +25,7 @@ my %args = (
     requires => {
         'Time::HiRes' => '0',
         'Try::Tiny' => '0',
-        'perl' => '5.008001',
+        'perl' => '5.022000',
     },
 
     recommends => {

--- a/META.json
+++ b/META.json
@@ -49,7 +49,7 @@
          "requires" : {
             "Time::HiRes" : "0",
             "Try::Tiny" : "0",
-            "perl" : "5.008001"
+            "perl" : "5.022000"
          }
       },
       "test" : {

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires 'perl', '5.008001';
+requires 'perl', '5.022000';
 requires 'Try::Tiny';
 requires 'Time::HiRes';
 


### PR DESCRIPTION
travis-ci dropped support of Perl 5.20, so it is hard for us to continue supporting Perl 5.20.

Xenial only supports 5.22, 5.24, 5.26, 5.28 and 5.30.
https://docs.travis-ci.com/user/reference/xenial/#perl-support