### PR TITLE
Fix leak when croak

### DIFF
--- a/src/Redis__Fast.xs
+++ b/src/Redis__Fast.xs
@@ -550,7 +550,7 @@ static void Redis__Fast_sync_reply_cb(redisAsyncContext* c, void* reply, void* p
             cbt->ret = Redis__Fast_decode_reply(self, (redisReply*)reply, cbt->collect_errors);
         }
     } else if(c->c.flags & REDIS_FREEING) {
-        DEBUG_MSG("%s", "redis feeing");
+        DEBUG_MSG("%s", "redis freeing");
         Safefree(cbt);
     } else {
         DEBUG_MSG("connect error: %s", c->errstr);

--- a/src/Redis__Fast.xs
+++ b/src/Redis__Fast.xs
@@ -446,7 +446,7 @@ static redis_fast_reply_t Redis__Fast_decode_reply(Redis__Fast self, redisReply*
         res.result = sv_2mortal(newSViv(reply->integer));
         break;
     case REDIS_REPLY_NIL:
-        res.result = sv_2mortal(newSV(0));
+        res.result = &PL_sv_undef;
         break;
 
     case REDIS_REPLY_ARRAY: {
@@ -511,7 +511,7 @@ static int Redis__Fast_call_reconnect_on_error(Redis__Fast self, redis_fast_repl
         ENTER;
         SAVETMPS;
 
-        sv_ret = ret.result ? ret.result : sv_2mortal(newSV(0));
+        sv_ret = ret.result ? ret.result : &PL_sv_undef;
         sv_err = ret.error;
         sv_cmd = sv_2mortal(newSVpvn((const char*)command_name, command_length));
 
@@ -1289,8 +1289,8 @@ CODE:
     Safefree(argv);
     Safefree(argvlen);
 
-    ST(0) = ret.result ? ret.result : sv_2mortal(newSV(0));
-    ST(1) = ret.error ? ret.error : sv_2mortal(newSV(0));
+    ST(0) = ret.result ? ret.result : &PL_sv_undef;
+    ST(1) = ret.error ? ret.error : &PL_sv_undef;
     XSRETURN(2);
 }
 
@@ -1367,8 +1367,8 @@ CODE:
     Safefree(argv);
     Safefree(argvlen);
 
-    ST(0) = ret.result ? ret.result : sv_2mortal(newSV(0));
-    ST(1) = ret.error ? ret.error : sv_2mortal(newSV(0));
+    ST(0) = ret.result ? ret.result : &PL_sv_undef;
+    ST(1) = ret.error ? ret.error : &PL_sv_undef;
     XSRETURN(2);
 }
 
@@ -1407,8 +1407,8 @@ CODE:
     Safefree(argv);
     Safefree(argvlen);
 
-    ST(0) = ret.result ? ret.result : sv_2mortal(newSV(0));
-    ST(1) = ret.error ? ret.error : sv_2mortal(newSV(0));
+    ST(0) = ret.result ? ret.result : &PL_sv_undef;
+    ST(1) = ret.error ? ret.error : &PL_sv_undef;
     XSRETURN(2);
 }
 


### PR DESCRIPTION
when croak in `Redis__Fast_run_cmd`, `Safefree` is not called.

```c
    ret = Redis__Fast_run_cmd(self, collect_errors, NULL, cb, argc, (const char**)argv, argvlen);
    Safefree(argv);
    Safefree(argvlen);
```

This causes leaking of `argv` and `argvlen`.
This pull request fixes it.