### PR TITLE
fix Segmentation fault when connection failed

### DIFF
--- a/t/53-fail-to-connect.t
+++ b/t/53-fail-to-connect.t
@@ -9,4 +9,18 @@ like exception {
     Redis::Fast->new(server => "localhost:0");
 }, qr/could not connect to redis server/i, 'fail to connect';
 
+my $redis = Redis::Fast->new(
+   reconnect => 0,
+   every => 50_000,
+   no_auto_connect_on_new => 1,
+   server => '127.0.0.1:6379',
+   write_timeout => 0.2,
+   read_timeout => 0.2,
+   cnx_timeout => 0.2,
+);
+
+eval { $redis->info(); };
+eval { $redis->info(); };
+eval { $redis->info(); };
+
 done_testing;


### PR DESCRIPTION
1. reconnect=0 still makes coredump if redis is down (may be stop using
it as flag at all) :)

```perl
my $redis = Redis::Fast->new(
   reconnect => 0,
   every => 50_000,
   no_auto_connect_on_new => 1,
   server => '127.0.0.1:6379',
   write_timeout => 0.2,
   read_timeout => 0.2,
   cnx_timeout => 0.2,
   debug => 1,
);

eval { $redis->info(); };
eval { $redis->info(); };
eval { $redis->info(); };
exit(0);
```

```
[lib/Redis/Fast.xs:422:Redis__Fast_reconnect]: start
[lib/Redis/Fast.xs:428:Redis__Fast_reconnect]: Not connected to any server
[lib/Redis/Fast.xs:430:Redis__Fast_reconnect]: finish
[lib/Redis/Fast.xs:724:Redis__Fast_run_cmd]: start INFO
[lib/Redis/Fast.xs:726:Redis__Fast_run_cmd]: pid check: previous pid is
0, now 11356
[lib/Redis/Fast.xs:728:Redis__Fast_run_cmd]: pid changed. create new
connection..
[lib/Redis/Fast.xs:369:Redis__Fast_connect]: start
[lib/Redis/Fast.xs:277:__build_sock]: start
[lib/Redis/Fast.xs:119:AddWrite]: flags = 2
[lib/Redis/Fast.xs:199:wait_for_event]: set WRITE, write_timeout = 0.200000
[lib/Redis/Fast.xs:210:wait_for_event]: select start, timeout is 0.200000
[lib/Redis/Fast.xs:217:wait_for_event]: poll returns 1
[lib/Redis/Fast.xs:237:wait_for_event]: ready to write
[lib/Redis/Fast.xs:254:Redis__Fast_connect_cb]: connected status = -1
[lib/Redis/Fast.xs:244:wait_for_event]: exception: POLLERR
[lib/Redis/Fast.xs:422:Redis__Fast_reconnect]: start
[lib/Redis/Fast.xs:428:Redis__Fast_reconnect]: Not connected to any server
[lib/Redis/Fast.xs:430:Redis__Fast_reconnect]: finish
[lib/Redis/Fast.xs:724:Redis__Fast_run_cmd]: start INFO
[lib/Redis/Fast.xs:726:Redis__Fast_run_cmd]: pid check: previous pid is
11356, now 11356
[lib/Redis/Fast.xs:771:Redis__Fast_run_cmd]: send command in sync mode
Segmentation fault (core dumped)
```

we must check `self->ac` after cailling `Redis__Fast_reconnect`, but some cases it is not checked.