### PR TITLE
fix broken tests using fork(2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+  workflow_dispatch:
 
 jobs:
   test-xt:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Redis
         uses: shogo82148/actions-setup-redis@v1
         with:
-          redis-version: "6.0"
+          redis-version: "6.2"
           auto-start: false
 
       - name: Cache CPAN modules

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Redis
 
 {{$NEXT}}
+    - fix broken tests using fork(2) #112
 
 0.29 2021-01-17T10:35:59Z
     - fix Segmentation fault when connection failed #105

--- a/t/03-pubsub.t
+++ b/t/03-pubsub.t
@@ -5,6 +5,7 @@ use strict;
 use Test::More;
 use Test::Fatal;
 use Test::Deep;
+use Test::SharedFork;
 use Redis::Fast;
 use lib 't/tlib';
 use Test::SpawnRedisServer qw( redis reap );
@@ -210,7 +211,7 @@ subtest 'server is killed while waiting for subscribe' => sub {
     diag("now, check wait_for_messages(), should die...");
     like(
       exception { $sub->wait_for_messages(0) },
-      qr/EOF from server/,
+      qr/EOF from server|Not connected to any server/,
       "properly died with EOF"
     );
     exit(0);


### PR DESCRIPTION
`t/03-pubsub.t` fails with `Failed test 'properly died with EOF'`.
but the test suite doesn't catch it.

```
t/03-pubsub.t .............. 3/?     # child is ready to test, signal parent to kill our server
    # parent killed pub/sub redis server, signal child to proceed
    # now, check wait_for_messages(), should die...
    # parent waiting for child 5812...

    #   Failed test 'properly died with EOF'
    #   at t/03-pubsub.t line 213.
    #                   'Not connected to any server at t/03-pubsub.t line 212.
    # '
    #     doesn't match '(?^:EOF from server)'
t/03-pubsub.t .............. 4/?     # CHILD: reconnected (with a 10s timeout)
    # CHILD: is ready to test, signal parent to restart our server
    # PARENT: killed pub/sub redis server, signal child to proceed
    # CHILD: launch wait_for_messages(2), with reconnect...
    # CHILD: reconnected (with a 10s timeout)
    # PARENT: has relaunched the server...
    # CHILD: after 2 sec, nothing yet, retrying
    # CHILD: launch wait_for_messages(2), with reconnect...
    # CHILD: after 2 sec, nothing yet, retrying
    # CHILD: launch wait_for_messages(2), with reconnect...
    # PARENT: waiting for child 5814...
    # CHILD: child received the message
```