### PR TITLE
use monotonic timer in tests

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,6 @@
 requires 'perl', '5.008001';
 requires 'Try::Tiny';
-requires 'Time::HiRes';
+requires 'Time::HiRes' => '>=1.77';
 
 on 'configure' => sub{
     requires 'Module::Build::XSUtil' => '>=0.02';

--- a/t/11-timeout.t
+++ b/t/11-timeout.t
@@ -12,6 +12,7 @@ use POSIX qw(strerror);
 use Carp;
 use IO::Socket::INET;
 use Test::TCP;
+use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC);
 
 subtest 'server replies quickly enough' => sub {
     my $server = Test::SpawnRedisTimeoutServer::create_server_with_timeout(0);
@@ -34,44 +35,43 @@ subtest "server doesn't replies quickly enough" => sub {
 };
 
 subtest "server doesn't respond at connection (cnx_timeout)" => sub {
-  SKIP: {
-    skip "This subtest is failing on some platforms", 4;
-	my $server = Test::TCP->new(code => sub {
-			my $port = shift;
-			my $sock = IO::Socket::INET->new(Listen => 1, LocalPort => $port, Proto => 'tcp', LocalAddr => '127.0.0.1') or croak "fail to listen on port $port";
-			while(1) {
-				sleep(1);
-			};
-	});
+    my $server = Test::TCP->new(code => sub {
+        my $port = shift;
+        my $sock = IO::Socket::INET->new(Listen => 1, LocalPort => $port, Proto => 'tcp', LocalAddr => '127.0.0.1') or croak "fail to listen on port $port";
+        while(1) {
+            sleep(1);
+        };
+    });
 
     my $redis;
-    my $start_time = time;
+    my $start_time = clock_gettime(CLOCK_MONOTONIC);
     isnt(
-         exception { $redis = Redis::Fast->new(server => '127.0.0.1:' . $server->port, cnx_timeout => 1); },
+         exception { $redis = Redis::Fast->new(server => '127.0.0.1:' . $server->port, cnx_timeout => 2); },
          undef,
          "the code died",
         );
-    ok(time - $start_time >= 1, "gave up late enough");
-    ok(time - $start_time < 5, "gave up soon enough");
+    my $end_time = clock_gettime(CLOCK_MONOTONIC);
+    ok($end_time - $start_time >= 1, "gave up late enough");
+    ok($end_time - $start_time < 5, "gave up soon enough");
     ok(!$redis, 'redis was not set');
-  }
 };
 
 subtest "server doesn't respond at connection with unreachable server (cnx_timeout)" => sub {
     my $redis;
-    my $start_time = time;
+    my $start_time = clock_gettime(CLOCK_MONOTONIC);
 
     # $server is one of example IP addresses.
     # it is reserved for documentation, so unreachable.
     my $server = "192.0.2.1:9998";
 
     isnt(
-         exception { $redis = Redis::Fast->new(server => $server, cnx_timeout => 1); },
+         exception { $redis = Redis::Fast->new(server => $server, cnx_timeout => 2); },
          undef,
          "the code died",
         );
-    ok(time - $start_time >= 1, "gave up late enough");
-    ok(time - $start_time < 5, "gave up soon enough");
+    my $end_time = clock_gettime(CLOCK_MONOTONIC);
+    ok($end_time - $start_time >= 1, "gave up late enough");
+    ok($end_time - $start_time < 5, "gave up soon enough");
     ok(!$redis, 'redis was not set');
 };
 

--- a/t/11-timeout.t
+++ b/t/11-timeout.t
@@ -35,13 +35,17 @@ subtest "server doesn't replies quickly enough" => sub {
 };
 
 subtest "server doesn't respond at connection (cnx_timeout)" => sub {
-    my $server = Test::TCP->new(code => sub {
-        my $port = shift;
-        my $sock = IO::Socket::INET->new(Listen => 1, LocalPort => $port, Proto => 'tcp', LocalAddr => '127.0.0.1') or croak "fail to listen on port $port";
-        while(1) {
-            sleep(1);
-        };
-    });
+SKIP: {
+    skip "This subtest is failing on some platforms", 4;
+    my $server = Test::TCP->new(
+        listen => 1,
+        code => sub {
+            my $sock = shift;
+            while(1) {
+                $sock->accept();
+            };
+        },
+    );
 
     my $redis;
     my $start_time = clock_gettime(CLOCK_MONOTONIC);
@@ -54,6 +58,7 @@ subtest "server doesn't respond at connection (cnx_timeout)" => sub {
     ok($end_time - $start_time >= 1, "gave up late enough");
     ok($end_time - $start_time < 5, "gave up soon enough");
     ok(!$redis, 'redis was not set');
+}
 };
 
 subtest "server doesn't respond at connection with unreachable server (cnx_timeout)" => sub {

--- a/t/53-signal.t
+++ b/t/53-signal.t
@@ -5,7 +5,7 @@ use Test::Fatal;
 use Redis::Fast;
 use lib 't/tlib';
 use Test::SpawnRedisServer;
-use Time::HiRes qw();
+use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC);
 
 my ($c, $srv) = redis();
 END { $c->() if $c }
@@ -21,23 +21,24 @@ ok($redis->ping, 'ping');
 $redis->select(2);
 
 subtest 'signal' => sub {
-    my $start = Time::HiRes::time;
-    my $sig;
-    local $SIG{ALRM} = sub { $sig = Time::HiRes::time };
+    my $start_time = clock_gettime(CLOCK_MONOTONIC);
+    my $sig_time;
+    local $SIG{ALRM} = sub { $sig_time = clock_gettime(CLOCK_MONOTONIC); };
     alarm 1;
     $redis->blpop('abc', 5);
-    my $end = Time::HiRes::time;
-    cmp_ok $sig - $start, '<=', 2, 'the signal handler is executed as soon as possible';
-    cmp_ok $end - $start, '>=', 4, 'the signal does not unblock the Redis command';
+    my $end_time = clock_gettime(CLOCK_MONOTONIC);
+    cmp_ok $sig_time - $start_time, '<=', 2, 'the signal handler is executed as soon as possible';
+    cmp_ok $end_time - $start_time, '>=', 4, 'the signal does not unblock the Redis command';
 };
 
 subtest 'die in signal' => sub {
-    my $start = Time::HiRes::time;
+    my $start_time = clock_gettime(CLOCK_MONOTONIC);
     local $SIG{ALRM} = sub { die "ALARM\n"; };
     alarm 1;
     is exception {  $redis->blpop('abc', 20); }, "ALARM\n";
-    my $end = Time::HiRes::time;
-    cmp_ok $end - $start, '<=', 2, 'the signal unblocks the Redis command';
+    my $end_time = clock_gettime(CLOCK_MONOTONIC);
+    cmp_ok $end_time - $start_time, '<=', 2, 'the signal unblocks the Redis command';
+    diag $start_time;
 };
 
 done_testing;


### PR DESCRIPTION
https://metacpan.org/pod/Time::HiRes#CAVEATS

- the core `time()` maybe rounding rather than truncating.
- `Time::HiRes::time()` adjusts the system clock that is not a monotonously increasing time
