### PR TITLE
install URI.pm explicitly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,9 @@ jobs:
           perl-version: ${{ matrix.perl }}
           install-modules-with: cpm
           install-modules-args: --with-develop --with-configure
-          install-modules: Minilla
+          # xxx: we not depend URI directly, however install it explicitly.
+          # because cpm sometimes installs old version of URI.
+          install-modules: Minilla URI
 
       - name: Set up Redis ${{ matrix.redis }}
         uses: shogo82148/actions-setup-redis@v1


### PR DESCRIPTION
Redis::Fast doesn't depend to URI directly, however install it explicitly.
because cpm sometimes installs old version of URI (v1.72 released on 2011, the latest is v5.10).